### PR TITLE
New integration update feature

### DIFF
--- a/jupyter_integrations_utility/util.py
+++ b/jupyter_integrations_utility/util.py
@@ -69,16 +69,16 @@ def displayMD(md):
     display(Markdown(md))
     
 def display_error(err):
-    display(Markdown(emoji.emojize(f"<span style='display:block; padding:6px; font-size:15px; background-color:#ffecee;'>:cross_mark: {err}</span>")))
+    display(Markdown(emoji.emojize(f"<span style='display:block; padding:6px; font-size:15px; color:#000000; background-color:#ffecee;'>:cross_mark: {err}</span>")))
     
 def display_warning(warn):
-    display(Markdown(emoji.emojize(f"<span style='display:block; padding:6px; font-size:15px; background-color:#fff9e7;'>:raised_hand: {warn}</span>")))
+    display(Markdown(emoji.emojize(f"<span style='display:block; padding:6px; font-size:15px; color:#000000; background-color:#fff9e7;'>:raised_hand: {warn}</span>")))
     
 def display_info(msg):
-    display(Markdown(emoji.emojize(f"<span style='display:block; padding:6px; font-size:15px; background-color:#e1fbfd;'>:information: {msg}</span>")))
+    display(Markdown(emoji.emojize(f"<span style='display:block; padding:6px; font-size:15px; color:#000000; background-color:#e1fbfd;'>:information: {msg}</span>")))
 
 def display_success(msg):
-    display(Markdown(emoji.emojize(f"<span style='display:block; padding:6px; font-size:15px; background-color:#e7fbf6;'>:check_mark_button: {msg}</span>")))
+    display(Markdown(emoji.emojize(f"<span style='display:block; padding:6px; font-size:15px; color:#000000; background-color:#e7fbf6;'>:check_mark_button: {msg}</span>")))
 
 def getHome(debug=False):
     home = ""

--- a/updater_core/updater_full.py
+++ b/updater_core/updater_full.py
@@ -174,7 +174,6 @@ class Updater(Addon):
                     elif b.origin == "loaded":
                         jiu.display_warning(f"{b.value} has been re-installed, but you need to \
                             restart your kernel for it to take effect.")
-                        jiu.displayMD(f"\n```\n{load_script}```")
                         
                     else:
                         jiu.display_error("You clicked on a button that has no `origin` property set and that's bad.")

--- a/updater_core/updater_full.py
+++ b/updater_core/updater_full.py
@@ -167,7 +167,7 @@ class Updater(Addon):
                     load_script = create_load_script(b.value.replace("jupyter_", ""))
 
                     if b.origin == "available":
-                        jiu.display_warning(f"{b.value} is installed to your environment now, \
+                        jiu.display_warning(f"{b.value} has been installed to your environment, \
                             but you need to copy the code block below to a new cell and run it.")
                         jiu.displayMD(f"\n```\n{load_script}```")
                         

--- a/updater_core/updater_utils/helpers.py
+++ b/updater_core/updater_utils/helpers.py
@@ -30,7 +30,7 @@ def install_integration(integration_name, repo_url, proxies):
         afile.extractall(integration_name)
     
     repo_source_dir = os.path.join(os.getcwd(), integration_name, os.listdir(integration_name)[0])
-    output = subprocess.run(["pip", "install", "--upgrade", "--force-reinstall", "."], cwd=repo_source_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output = subprocess.run(["pip", "install", "--upgrade", "--force-reinstall", "--no-deps", "."], cwd=repo_source_dir)
     
     return output
 


### PR DESCRIPTION
# What changed
- removed stdout and stderr piping from the installation function so that we can troubleshoot more easily with a user (this will display stderr and stdout in their command shell window, not in Jupyter)
- Refined success logic and messages
- added --no-deps flag to pip install so we don't overwrite dependencies
- set font color to black to override the dark theme's white text, which was making colored messages unreadable in dark mode